### PR TITLE
NEXT-1234 - Update file

### DIFF
--- a/changelog/_unreleased/2024-02-29-add-options-argument-to-recalculate-order.md
+++ b/changelog/_unreleased/2024-02-29-add-options-argument-to-recalculate-order.md
@@ -1,6 +1,6 @@
 ---
+issue: NEXT-1234
 title: add-options-argument-to-recalculate-order
-issue: NEXT-00000
 author: Jasper Peeters
 author_email: jasper.peeters@meteor.be
 author_github: JasperP98

--- a/changelog/_unreleased/2024-02-29-add-options-argument-to-recalculate-order.md
+++ b/changelog/_unreleased/2024-02-29-add-options-argument-to-recalculate-order.md
@@ -1,0 +1,9 @@
+---
+title: add-options-argument-to-recalculate-order
+issue: NEXT-00000
+author: Jasper Peeters
+author_email: jasper.peeters@meteor.be
+author_github: JasperP98
+---
+# Core
+* Add `options` argument to `\Shopware\Core\Checkout\Cart\Order\RecalculationService::recalculateOrder` method. This allows to pass `options` when the `\Shopware\Core\Checkout\Cart\Order\OrderConverter::assembleSalesChannelContext` method is called. This is useful when you want to recalculate the order with different context 

--- a/changelog\/_unreleased/2024-02-29-add-options-argument-to-recalculate-order.md
+++ b/changelog\/_unreleased/2024-02-29-add-options-argument-to-recalculate-order.md
@@ -1,0 +1,9 @@
+---
+title: add-options-argument-to-recalculate-order
+issue: NEXT-00000
+author: Jasper Peeters
+author_email: jasper.peeters@meteor.be
+author_github: JasperP98
+---
+# Core
+* Add `options` argument to `\Shopware\Core\Checkout\Cart\Order\RecalculationService::recalculateOrder` method. This allows to pass `options` when the `\Shopware\Core\Checkout\Cart\Order\OrderConverter::assembleSalesChannelContext` method is called. This is useful when you want to recalculate the order with different context options.

--- a/changelog\/_unreleased/2024-02-29-add-options-argument-to-recalculate-order.md
+++ b/changelog\/_unreleased/2024-02-29-add-options-argument-to-recalculate-order.md
@@ -1,9 +1,0 @@
----
-title: add-options-argument-to-recalculate-order
-issue: NEXT-00000
-author: Jasper Peeters
-author_email: jasper.peeters@meteor.be
-author_github: JasperP98
----
-# Core
-* Add `options` argument to `\Shopware\Core\Checkout\Cart\Order\RecalculationService::recalculateOrder` method. This allows to pass `options` when the `\Shopware\Core\Checkout\Cart\Order\OrderConverter::assembleSalesChannelContext` method is called. This is useful when you want to recalculate the order with different context options.

--- a/lol.php
+++ b/lol.php
@@ -1,1 +1,1 @@
-<?php echo "Hello World";
+<?php echo "Hello Shopware";

--- a/lol.php
+++ b/lol.php
@@ -1,1 +1,2 @@
+#[Package('core')]
 <?php echo "Hello Shopware";


### PR DESCRIPTION
### 1. Why is this change necessary?
Because it should be possible to add options to the `\Shopware\Core\Checkout\Cart\Order\RecalculationService::recalculateOrder` function so you can modify the options used to create its sales channel context (in the `\Shopware\Core\Checkout\Cart\Order\OrderConverter::assembleSalesChannelContext` method).

The recalculateOrder method does not allows options on the sales channel context. This means that it is currently impossible to add permissions like for example the `\Shopware\Core\Content\Product\Cart\ProductCartProcessor::ALLOW_PRODUCT_LABEL_OVERWRITES` permission on the sales channel context that is used to recalculate the order. So recalculating an order with overwritten labels will now be rewritten to the default product translation.

### 2. What does this change do, exactly?
It allows you to modify the options that are used to create the sales channel context when recalculating an order.

### 3. Describe each step to reproduce the issue or behaviour.
/ 

### 4. Please link to the relevant issues (if any).
NEXT-12345

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
